### PR TITLE
Add tests to headerless table and change default header to None

### DIFF
--- a/src/widgets/table.rs
+++ b/src/widgets/table.rs
@@ -112,7 +112,7 @@ where
         Table {
             block: None,
             style: Style::default(),
-            header: Some(H::default()),
+            header: None,
             header_style: Style::default(),
             widths: &[],
             column_spacing: 1,
@@ -157,6 +157,7 @@ where
         self
     }
 
+    /// Set header to None, so it will not be rendered
     pub fn headerless(mut self) -> Table<'a, H, R> {
         self.header = None;
         self
@@ -376,5 +377,16 @@ mod tests {
     fn table_invalid_percentages() {
         Table::new([""].iter(), vec![Row::Data([""].iter())].into_iter())
             .widths(&[Constraint::Percentage(110)]);
+    }
+
+    #[test]
+    fn table_headerless_valid() {
+        let table = Table::new([""].iter(), vec![Row::Data([""].iter())].into_iter())
+            .headerless()
+            .widths(&[Constraint::Percentage(100)]);
+        match table.header {
+            Some(_) => panic!("There should be no header in headerless table"),
+            None => {}
+        }
     }
 }


### PR DESCRIPTION
Короче говоря, я пытался пару дней удалить из new аргумент header, но с той реализацией, которая есть, совершенно невозможно просто удалить его (ну вот эта проблема, о которой ты писал, с выведением  типов). Даже если сменить тип header на НЕ шаблонный, он просто не может Display поместить в Option, т.е. Dispay не Sized type. (Это известаная проблема, которую в расте хотят пофиксить).

Предлагаю так запушить. Лучше так, чем никак.